### PR TITLE
Update oneup/uploader-bundle to 1.9.4 (security release)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "friendsofsymfony/user-bundle": "~2.0@dev",
         "doctrine/doctrine-fixtures-bundle": "2.3.*",
         "doctrine/doctrine-migrations-bundle": "^1.0",
-        "oneup/uploader-bundle": "~1.4",
+        "oneup/uploader-bundle": "^1.9.4",
         "cocur/slugify": "^1.4",
         "liip/imagine-bundle": "^1.5",
         "knplabs/knp-paginator-bundle": "2.5.1",


### PR DESCRIPTION
See https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp.